### PR TITLE
Rf_error() → Rcpp::stop()

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,16 +1,13 @@
-# For help debugging build failures open an issue on the RStudio community with the 'github-actions' tag.
-# https://community.rstudio.com/new-topic?category=Package%20development&tags=github-actions
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches:
-      - main
-      - master
+    branches: [main, master]
   pull_request:
-    branches:
-      - main
-      - master
 
-name: R-CMD-check
+name: R-CMD-check.yaml
+
+permissions: read-all
 
 jobs:
   R-CMD-check:
@@ -22,65 +19,33 @@ jobs:
       fail-fast: false
       matrix:
         config:
+          - {os: macos-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
-          - {os: macOS-latest, r: 'release'}
-          - {os: ubuntu-20.04, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          - {os: ubuntu-20.04, r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
 
     env:
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
 
-      - uses: r-lib/actions/setup-pandoc@v1
-
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
-
-      - name: Cache R packages
-        if: runner.os != 'Windows'
-        uses: actions/cache@v2
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+          extra-packages: any::rcmdcheck
+          needs: check
 
-      - name: Install system dependencies
-        if: runner.os == 'Linux'
-        run: |
-          while read -r cmd
-          do
-            eval sudo $cmd
-          done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
-
-      - name: Install dependencies
-        run: |
-          remotes::install_deps(dependencies = TRUE)
-          remotes::install_cran("rcmdcheck")
-        shell: Rscript {0}
-
-      - name: Check
-        env:
-          _R_CHECK_CRAN_INCOMING_REMOTE_: false
-        run: |
-          options(crayon.enabled = TRUE)
-          rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
-        shell: Rscript {0}
-
-      - name: Upload check results
-        if: failure()
-        uses: actions/upload-artifact@main
+      - uses: r-lib/actions/check-r-package@v2
         with:
-          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
-          path: check
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,9 +9,9 @@ Authors@R:
            email = "frederick.boehm@gmail.com",
            comment = c(ORCID = "0000-0002-1644-5931"))
 Description: We implement an
-    adaptation of Jiang & Zeng's (1995) <https://www.genetics.org/content/140/3/1111> likelihood ratio test for testing
+    adaptation of Jiang & Zeng's (1995) <doi:10.1093/genetics/140.3.1111> likelihood ratio test for testing
     the null hypothesis of pleiotropy against the alternative hypothesis,
-    two separate quantitative trait loci. The test differs from that in Jiang & Zeng (1995) <https://www.genetics.org/content/140/3/1111>
+    two separate quantitative trait loci. The test differs from that in Jiang & Zeng (1995)
     and that in Tian et al. (2016) <doi:10.1534/genetics.115.183624> in
     that our test accommodates multiparental populations.
 License: MIT + file LICENSE

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: qtl2pleio
 Title: Testing Pleiotropy in Multiparental Populations
-Version: 1.4.3.9000
+Version: 1.4.3.9001
 Authors@R:
     person(given = "Frederick J",
            family = "Boehm",
@@ -11,7 +11,7 @@ Authors@R:
 Description: We implement an
     adaptation of Jiang & Zeng's (1995) <https://www.genetics.org/content/140/3/1111> likelihood ratio test for testing
     the null hypothesis of pleiotropy against the alternative hypothesis,
-    two separate quantitative trait loci. The test differs from that in Jiang & Zeng (1995) <https://www.genetics.org/content/140/3/1111> 
+    two separate quantitative trait loci. The test differs from that in Jiang & Zeng (1995) <https://www.genetics.org/content/140/3/1111>
     and that in Tian et al. (2016) <doi:10.1534/genetics.115.183624> in
     that our test accommodates multiparental populations.
 License: MIT + file LICENSE
@@ -43,7 +43,7 @@ LinkingTo:
     Rcpp,
     RcppEigen
 Encoding: UTF-8
-Language: en-US 
+Language: en-US
 LazyData: true
 NeedsCompilation: yes
 RoxygenNote: 7.1.1

--- a/README.Rmd
+++ b/README.Rmd
@@ -21,7 +21,7 @@ knitr::opts_chunk$set(
 
 [![R-CMD-check](https://github.com/fboehm/qtl2pleio/workflows/R-CMD-check/badge.svg)](https://github.com/fboehm/qtl2pleio/actions)
 [![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/qtl2pleio)](https://cran.r-project.org/package=qtl2pleio)
-[![Coverage Status](https://img.shields.io/codecov/c/github/fboehm/qtl2pleio/master.svg)](https://codecov.io/github/fboehm/qtl2pleio?branch=master)
+[![Coverage Status](https://img.shields.io/codecov/c/github/fboehm/qtl2pleio/master.svg)](https://app.codecov.io/github/fboehm/qtl2pleio?branch=master)
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![status](https://joss.theoj.org/papers/66bca5dc3d2e72b6259159bad07aafaf/status.svg)](https://joss.theoj.org/papers/10.21105/joss.01435)
 [![DOI](https://zenodo.org/badge/104493705.svg)](https://zenodo.org/badge/latestdoi/104493705)
@@ -33,7 +33,7 @@ knitr::opts_chunk$set(
 
 `qtl2pleio` is a software package for use with the [R statistical computing environment](https://cran.r-project.org/). `qtl2pleio` is freely available for download and use. I share it under the [MIT license](https://opensource.org/licenses/mit-license.php). The user will also want to download and install the [`qtl2` R package](https://kbroman.org/qtl2/).
 
-Click [here](https://mybinder.org/v2/gh/fboehm/qtl2pleio/master?urlpath=rstudio) to explore `qtl2pleio` within a live [Rstudio](https://rstudio.com/) session in "the cloud".
+Click [here](https://mybinder.org/v2/gh/fboehm/qtl2pleio/master?urlpath=rstudio) to explore `qtl2pleio` within a live [Rstudio](https://posit.co/download/rstudio-desktop/) session in "the cloud".
 
 ## Contributor guidelines
 
@@ -53,7 +53,7 @@ a QTL in a common region, to distinguish between pleiotropy (the null
 hypothesis, that they are affected by a common QTL) and the
 alternative that they are affected by separate QTL. It extends the
 likelihood ratio test of [Jiang and Zeng
-(1995)](https://www.genetics.org/content/140/3/1111.long) for
+(1995)](https://doi.org/10.1093/genetics/140.3.1111) for
 multiparental populations, such as Diversity Outbred mice, including
 the use of multivariate polygenic random effects to account for population structure.
 `qtl2pleio` data structures are those used in the

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![R-CMD-check](https://github.com/fboehm/qtl2pleio/workflows/R-CMD-check/badge.svg)](https://github.com/fboehm/qtl2pleio/actions)
 [![CRAN\_Status\_Badge](https://www.r-pkg.org/badges/version/qtl2pleio)](https://cran.r-project.org/package=qtl2pleio)
 [![Coverage
-Status](https://img.shields.io/codecov/c/github/fboehm/qtl2pleio/master.svg)](https://codecov.io/github/fboehm/qtl2pleio?branch=master)
+Status](https://img.shields.io/codecov/c/github/fboehm/qtl2pleio/master.svg)](https://app.codecov.io/github/fboehm/qtl2pleio?branch=master)
 [![Project Status: Active – The project has reached a stable, usable
 state and is being actively
 developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
@@ -24,7 +24,7 @@ package](https://kbroman.org/qtl2/).
 
 Click
 [here](https://mybinder.org/v2/gh/fboehm/qtl2pleio/master?urlpath=rstudio)
-to explore `qtl2pleio` within a live [Rstudio](https://rstudio.com/)
+to explore `qtl2pleio` within a live [Rstudio](https://posit.co/download/rstudio-desktop/)
 session in “the cloud”.
 
 ## Contributor guidelines
@@ -49,7 +49,7 @@ a QTL in a common region, to distinguish between pleiotropy (the null
 hypothesis, that they are affected by a common QTL) and the alternative
 that they are affected by separate QTL. It extends the likelihood ratio
 test of [Jiang and Zeng
-(1995)](https://www.genetics.org/content/140/3/1111.long) for
+(1995)](https://doi.org/10.1093/genetics/140.3.1111) for
 multiparental populations, such as Diversity Outbred mice, including the
 use of multivariate polygenic random effects to account for population
 structure. `qtl2pleio` data structures are those used in the

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,23 +1,26 @@
 citHeader("To cite qtl2pleio in publications use:")
 
-citEntry(entry="article",
+bibentry(bibtype="article",
          title = "Testing pleiotropy vs. separate QTL in multiparental populations",
-         author = personList(person(c("Frederick", "J."), "Boehm"),
-                             person(c("Elissa", "J."), "Chesler"),
-                             person(c("Brian", "S."), "Yandell"),
-                             person(c("Karl", "W."), "Broman")),
+         author = c(person(c("Frederick", "J."), "Boehm"),
+                    person(c("Elissa", "J."), "Chesler"),
+                    person(c("Brian", "S."), "Yandell"),
+                    person(c("Karl", "W."), "Broman")),
          journal = "G3",
          year = 2019,
          volume = 9,
          issue = 7,
-         url = "https://www.g3journal.org/content/9/7/2317",
-         eprint = "https://www.g3journal.org/content/ggg/9/7/2317.full.pdf",
+         pages = "2317-2324",
+         doi = "10.1093/genetics/140.3.1111",
+         url = "https://doi.org/10.1534/g3.119.400098",
+         eprint = "https://academic.oup.com/g3journal/article-pdf/9/7/2317/40667800/g3journal2317.pdf",
          key = "Boehm2019testing",
 
          textVersion =
              paste("Boehm FJ, Chesler EJ, Yandell BS, Broman KW",
-                   "(2019) Testing pleiotropy vs. separate QTL in multiparental populations", " G3 ",
-                   "https://www.g3journal.org/content/9/7/2317")
+                   "(2019) Testing pleiotropy vs. separate QTL in multiparental populations.",
+                   "G3 9:2317-2324",
+                   "doi:10.1534/g3.119.400098")
          )
 
 

--- a/src/matrix.cpp
+++ b/src/matrix.cpp
@@ -18,7 +18,7 @@ NumericVector find_matching_cols(const NumericMatrix& mat, const double tol=1e-1
   const int nrow = mat.rows();
   NumericVector result(ncol);
 
-  if(ncol < 1) Rf_error("Matrix has 0 columns");
+  if(ncol < 1) Rcpp::stop("Matrix has 0 columns");
 
   result[0] = -1;
   if(ncol==1) return(result);


### PR DESCRIPTION
- `Rf_error()` → `Rcpp::stop()` in `src/matrix.cpp` as reported by Rcpp team (Issue #48)

Also:
- replace a URL with a DOI in DESCRIPTION file
- fix some URLs in README
- revisions to inst/CITATION to avoid warnings, and add page numbers, DOI, etc.
- update github r-cmd-check workflow